### PR TITLE
fix strange behavior of gets_s when user type EXACTLY N - 1 character

### DIFF
--- a/lib/libc/stdio/gets_s.c
+++ b/lib/libc/stdio/gets_s.c
@@ -54,7 +54,7 @@ _gets_s(char *buf, rsize_t n)
    	 */
 
 	/* This prevents various alert via __throw_constraint_handler_s() if 
- 	 * the user type more than N - 1 characters, when functions flush stdin
+ 	 * the user type more than N - 1 characters, when function flush stdin
   	 * buffer
    	 */
 	signal = 1;


### PR DESCRIPTION
% ./gets_s 
Type a letter:
aa
You typed the letter: aa
% ./gets_s
Type a letter:
aaaaa
You typed the letter: aaaa
% ./gets_s
Type a letter:
aaaa

You typed the letter: aaaa
% ./fixgets_s
Type a letter:
aa
Type a letter:
aaaaa
gets_s : end of buffer [ 7 ]
You typed the letter: a1 = aa
a2 = aaaa
% ./fixgets_s
Type a letter:
aaaa
Type a letter:
aaaaa
gets_s : end of buffer [ 7 ]
You typed the letter: a1 = aaaa
a2 = aaaa
% 

To run on stadalone, I subst __throw function by printf to see the function works